### PR TITLE
fix: remove duplicate early team build card

### DIFF
--- a/index.html
+++ b/index.html
@@ -4091,29 +4091,6 @@
                                         class="hackathon-carousel-image"
                                         loading="lazy"
                                         src="data:image/gif;base64,R0lGODlhAQABAAAAACw="
-                                        data-src="images/hackathon/timeline-happening-20.webp"
-                                        width="1080"
-                                        height="809"
-                                        alt="Hunter Ho and teammate at early startup hackathon table"
-                                        decoding="async"
-                                    />
-                                    <figcaption>
-                                        <span>Startup | Hackathon | Team</span>
-                                        <strong>Early Team Build</strong>
-                                        <em>Prototype-room snapshot</em>
-                                    </figcaption>
-                                </figure>
-                            </article>
-                            <article
-                                class="hackathon-carousel-card"
-                                data-motion-card
-                                data-carousel-card
-                            >
-                                <figure class="hackathon-carousel-frame">
-                                    <img
-                                        class="hackathon-carousel-image"
-                                        loading="lazy"
-                                        src="data:image/gif;base64,R0lGODlhAQABAAAAACw="
                                         data-src="images/hackathon/timeline-happening-19.webp"
                                         width="1200"
                                         height="675"

--- a/tests/portfolio-content.test.js
+++ b/tests/portfolio-content.test.js
@@ -617,7 +617,6 @@ const requiredAssets = [
   "images/hackathon/timeline-happening-17.webp",
   "images/hackathon/timeline-happening-18.webp",
   "images/hackathon/timeline-happening-19.webp",
-  "images/hackathon/timeline-happening-20.webp",
   "images/hackathon/timeline-happening-21.webp",
   "images/hackathon/timeline-happening-22.webp",
   "images/hackathon/timeline-happening-23.webp",
@@ -2739,14 +2738,12 @@ assert.ok(
   "Standalone Champion Stage proof wall should be removed",
 );
 assert.ok(
-  (hackathonWinsSection.match(/class="hackathon-carousel-card/g) || [])
-    .length >= 25,
-  "Timeline gallery should include the full uploaded event photo set and stay open-ended for future additions",
+  (hackathonWinsSection.match(/class="hackathon-carousel-card/g) || []).length >= 24,
+  "Timeline gallery should keep the deduplicated uploaded event photo set and stay open-ended for future additions",
 );
 assert.ok(
-  (hackathonWinsSection.match(/class="hackathon-carousel-image"/g) || [])
-    .length >= 25,
-  "Every timeline card should use a real image element",
+  (hackathonWinsSection.match(/class="hackathon-carousel-image"/g) || []).length >= 24,
+  "Every deduplicated timeline card should use a real image element",
 );
 assert.ok(
   !hackathonWinsSection.includes("hackathon-card-placeholder"),
@@ -2784,7 +2781,6 @@ for (const hackathonAsset of [
   "images/hackathon/timeline-happening-17.webp",
   "images/hackathon/timeline-happening-18.webp",
   "images/hackathon/timeline-happening-19.webp",
-  "images/hackathon/timeline-happening-20.webp",
   "images/hackathon/timeline-happening-21.webp",
   "images/hackathon/timeline-happening-22.webp",
   "images/hackathon/timeline-happening-23.webp",


### PR DESCRIPTION
## Summary
- remove the duplicate Early Team Build timeline card
- keep the stronger Startup Weekend / Teamwork before the pitch card
- update timeline regression expectations from 25 to 24 cards/images

## Verification
- node --check js/main.js
- node --check js/main.min.js
- pnpm test
- git diff --check
- local HTML count check confirms one Early Team Build remains